### PR TITLE
Use std::make_shared to avoid double deletion of the same pointer

### DIFF
--- a/src/spring2024/s24_my_ptr.cpp
+++ b/src/spring2024/s24_my_ptr.cpp
@@ -243,8 +243,7 @@ int main() {
   }
   std::cout << "Count: " << sp1.use_count() << std::endl;  // Output: 1
   // 1. Always make a copy of an existing std::shared_ptr.
-  int *rp = new int;
-  std::shared_ptr<int> sp3{rp};
+  std::shared_ptr<int> sp3 = std::make_shared<int>();
   // std::shared_ptr<int> sp4{ rp }; // WRONG!
   std::shared_ptr<int> sp4{sp3};
   // 2. Always use std::make_shared() to create a shared_ptr.


### PR DESCRIPTION
The problem in the code is that `rp` is being managed by two different `std::shared_ptr` instances (`sp3` and `sp4`), which can lead to double deletion of the same pointer. The correct approach is to use `std::make_shared` to create the shared pointer, which ensures that the pointer is managed correctly.